### PR TITLE
rollback일 경우 로컬 파일 검사 제외 추가

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -89,7 +89,7 @@ function startRollback(sets) {
     color.cyan(opts.applicationName),
     color.cyan(opts.versionLabel));
 
-  deferred.resolve(opts.versionLabel);
+  deferred.resolve({ApplicationVersion: {VersionLabel: opts.versionLabel}});
 
   return deferred.promise;
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -23,20 +23,23 @@ module.exports = function(opts) {
   if(!opts.environmentName) {
     throw new Error('Param missing [environmentName]');
   }
-  if(!opts.sourceBundle) {
-    throw new Error('Param missing [sourceBundle]');
-  }
 
-  try {
-    fs.statSync(opts.sourceBundle);
-  } catch(e) {
-    var error_msg;
-    if(e.code === 'ENOENT' ) {
-      error_msg = new Error('Invalid sourceBundle, It is not exist ' + opts.sourceBundle);
-    } else {
-      error_msg = e;
+  if (!opts.rollback) {
+    if(!opts.sourceBundle) {
+      throw new Error('Param missing [sourceBundle]');
     }
-    throw error_msg;
+
+    try {
+      fs.statSync(opts.sourceBundle);
+    } catch(e) {
+      var error_msg;
+      if(e.code === 'ENOENT' ) {
+        error_msg = new Error('Invalid sourceBundle, It is not exist ' + opts.sourceBundle);
+      } else {
+        error_msg = e;
+      }
+      throw error_msg;
+    }
   }
 
   sets.opts = _.pick(opts,[


### PR DESCRIPTION
롤백일 경우에는 S3에 존재하는 versionLabel에 해당하는 zip파일을 그대로
쓰므로 로컬의 sourceBundle 존재 여부를 검사할 필요가 없다.
추가적으로 startRollback에서 넘겨주는 데이터를 updateEnvironment에서
사용하는 형태에 맞춰주었다.